### PR TITLE
Update gitignore 2026 01 01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,60 @@
-# https://dart.dev/guides/libraries/private-files
-# Created by `dart pub`
+.DS_Store
+.atom/
+.idea
+.packages
+.pub/
 .dart_tool/
+.vscode/
+*.iml
 
-# Avoid committing pubspec.lock for library packages; see
-# https://dart.dev/guides/libraries/private-files#pubspeclock.
+# Gradle?
+.uuid
+
 pubspec.lock
 
-# vscode
-.vscode/
+# iOS and macOS dependencies
+.build/
+Podfile.lock
+Pods/
+.swiftpm/
+.symlinks/
 
-build/
+*instrumentscli*.trace
+*.cipd
+
+# Build directories are produced when building using the Flutter CLI.
+build
+
+# This file is produced as a back-up when web_benchmarks fails to parse a
+# Chrome trace.
+chrome-trace.json
+
+# Generated files on example apps
+flutter_export_environment.sh
+.flutter-plugins*
+local.properties
+keystore.properties
+**/Flutter/Generated.xcconfig
+**/Flutter/App.framework/
+**/Flutter/ephemeral/
+**/Flutter/Flutter.podspec
+**/Flutter/Flutter.framework/
+**/Flutter/flutter_assets/
+
+ServiceDefinitions.json
+xcuserdata/
+**/DerivedData/
+
+generated_plugin_registrant.*
+GeneratedPluginRegistrant.*
+
+# Gradle 
+**/gradle-wrapper.jar
+.gradle/
+gradlew
+gradlew.bat
+.cxx/
+
+.project
+.classpath
+.settings


### PR DESCRIPTION
## Summary

Based on https://github.com/flutter/packages/blob/main/.gitignore we updated gitignore file.